### PR TITLE
Fix iPadOS label

### DIFF
--- a/index.html
+++ b/index.html
@@ -382,7 +382,7 @@
             ChromeOS</a>.
           </dd>
           <dt>
-            ios
+            ipados
           </dt>
           <dd>
             For <a href="https://www.apple.com/ipados/">Apple iPadOS</a>.


### PR DESCRIPTION
Both platforms, iOS and iPadOS should probably be distinct since the form factors are distinct.